### PR TITLE
setter avsender til helsepersonell hvis navn mangler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -117,12 +117,12 @@ fun createAvsenderMottakerValidFnr(avsenderFnr: String, legeerklaering: Legeerkl
     id = avsenderFnr,
     idType = "FNR",
     land = "Norge",
-    navn = legeerklaering.signatur.navn ?: ""
+    navn = legeerklaering.signatur.navn ?: "Helsepersonell"
 )
 
 fun createAvsenderMottakerNotValidFnr(legeerklaering: Legeerklaering): AvsenderMottaker = AvsenderMottaker(
     land = "Norge",
-    navn = legeerklaering.signatur.navn ?: ""
+    navn = legeerklaering.signatur.navn ?: "Helsepersonell"
 )
 
 fun createTittleJournalpost(validationResult: ValidationResult, signaturDato: LocalDateTime): String {


### PR DESCRIPTION
Automatisk journalføring feiler når navn på avsender ikke er satt. Både Ida og jeg mener at vi vanligvis setter "helsepersonell" som avsender der vi mangler navn. 

OBS: Må ikke merges før Camilla har sagt ok :) 